### PR TITLE
Qualify absolute claims in blog content

### DIFF
--- a/blog/edgebrain-ai-edge-intelligence-platform.html
+++ b/blog/edgebrain-ai-edge-intelligence-platform.html
@@ -116,7 +116,7 @@
         <p>So I built EdgeBrain.</p>
 
         <h2>What EdgeBrain Does</h2>
-        <p>EdgeBrain is an <strong>AI-powered edge intelligence platform</strong> that runs 100% locally. Here's what it includes:</p>
+        <p>EdgeBrain is an <strong>AI-powered edge intelligence platform</strong> designed to run locally. Here's what it includes:</p>
         <ul>
           <li><strong>11 virtual IoT devices</strong> across 3 rooms (Living Room, Bedroom, Kitchen) — temperature, motion, energy, humidity, and light sensors with realistic circadian patterns and Gaussian noise</li>
           <li><strong>Multi-agent AI system</strong> with three specialized agents: Data Agent (validates and stores), Decision Agent (evaluates strategies), and Action Agent (executes commands)</li>


### PR DESCRIPTION
Softens 'runs 100% locally' to 'designed to run locally' in EdgeBrain blog post to avoid overpromising.